### PR TITLE
Fix hotcold Bézier sampling: arc length in RGB (issue #2)

### DIFF
--- a/bipolar.py
+++ b/bipolar.py
@@ -25,21 +25,19 @@ def _ratquad_bezier_rgb(p0, p1, p2, w, t):
     return num / den[:, np.newaxis]
 
 
-def _hsl_lightness_rgb(rgb):
-    """HSL lightness L = (max(R,G,B) + min(R,G,B)) / 2; rgb is (n, 3)."""
+def _grayscale_axis_coordinate_rgb(rgb):
+    """Scalar along the achromatic diagonal: (R+G+B)/3 for each row; rgb is (n, 3)."""
     rgb = np.asarray(rgb, dtype=float)
-    mx = np.max(rgb, axis=1)
-    mn = np.min(rgb, axis=1)
-    return (mx + mn) * 0.5
+    return rgb.mean(axis=1)
 
 
-def _resample_uniform_hsl_lightness(rgb_dense, n_samples, rgb_mix=1e-4):
+def _resample_uniform_grayscale_axis(rgb_dense, n_samples, rgb_mix=1e-4):
     """
-    Resample the polyline through rgb_dense so LUT steps advance ~uniformly
-    in cumulative |ΔL| along the path, where L is HSL lightness (the same L as
-    in ``colorsys.rgb_to_hls``). Grays (R=G=B) lie on the RGB diagonal and have
-    L=t. A small Euclidean RGB term keeps spacing well-defined where L is
-    flat along saturated segments (uniform Bézier t still bunches there).
+    Resample the polyline through ``rgb_dense`` so LUT steps advance ~uniformly
+    in cumulative ``|Δm|`` with ``m = (R+G+B)/3`` (projection onto the gray
+    diagonal in RGB). A small Euclidean RGB term keeps spacing well-defined
+    where ``m`` is flat along the path; if the combined metric collapses,
+    fall back to RGB chord length only.
     """
     n_samples = int(n_samples)
     rgb_dense = np.asarray(rgb_dense, dtype=float)
@@ -47,10 +45,10 @@ def _resample_uniform_hsl_lightness(rgb_dense, n_samples, rgb_mix=1e-4):
         raise ValueError('n_samples must be at least 2')
     if len(rgb_dense) < 2:
         return np.repeat(rgb_dense[:1], n_samples, axis=0)
-    L = _hsl_lightness_rgb(rgb_dense)
-    dL = np.abs(np.diff(L))
+    m = _grayscale_axis_coordinate_rgb(rgb_dense)
+    dm = np.abs(np.diff(m))
     drgb = np.linalg.norm(np.diff(rgb_dense, axis=0), axis=1)
-    seg = dL + rgb_mix * drgb
+    seg = dm + rgb_mix * drgb
     cum = np.concatenate([[0.0], np.cumsum(seg)])
     s_max = cum[-1]
     if s_max <= 0:
@@ -202,10 +200,11 @@ def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
         Rational Bézier weight on the middle control point for each smooth
         segment through the RGB cube (default 1). Larger values pull the path
         toward the middle control. Lookup rows are resampled from a dense
-        uniform-`t` Bézier using ~uniform steps in cumulative HSL lightness
-        change along the path (with a tiny RGB chord term where L is flat),
-        instead of uniform `t` (which bunches samples toward the endpoints;
-        see issue #2).
+        uniform-`t` Bézier using ~uniform steps in cumulative ``|Δm|`` along the
+        path, with ``m = (R+G+B)/3`` (linear spacing along the grayscale /
+        achromatic diagonal in RGB), plus a tiny RGB chord term where ``m`` is
+        nearly flat. Uniform ``t`` alone bunches samples toward the endpoints
+        on rational quadratics.
 
     Returns
     -------
@@ -284,7 +283,7 @@ def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
     p_end2 = np.asarray(data[4], dtype=float)
 
     n_half = lutsize // 2
-    # Dense uniform t, then resample by cumulative |Δ HSL lightness| along the path
+    # Dense uniform t, then resample by cumulative |Δ(R+G+B)/3| along the path
     # (uniform Bézier t bunches samples toward the endpoints on rational quadratics).
     n_dense = max(8192, lutsize * 64)
     t_dense = np.linspace(0.0, 1.0, n_dense)
@@ -292,8 +291,8 @@ def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
     rgb1_dense = _ratquad_bezier_rgb(p0, p_mid1, p_end1, weight, t_dense)
     rgb2_dense = _ratquad_bezier_rgb(p0, p_mid2, p_end2, weight, t_dense)
 
-    rgb1 = _resample_uniform_hsl_lightness(rgb1_dense, n_half)
-    rgb2 = _resample_uniform_hsl_lightness(rgb2_dense, n_half)
+    rgb1 = _resample_uniform_grayscale_axis(rgb1_dense, n_half)
+    rgb2 = _resample_uniform_grayscale_axis(rgb2_dense, n_half)
 
     ynew = np.concatenate((rgb1[1:][::-1], rgb2))
     np.clip(ynew, 0.0, 1.0, out=ynew)

--- a/bipolar.py
+++ b/bipolar.py
@@ -25,10 +25,21 @@ def _ratquad_bezier_rgb(p0, p1, p2, w, t):
     return num / den[:, np.newaxis]
 
 
-def _arc_length_uniform_rgb(rgb_dense, n_samples):
+def _hsl_lightness_rgb(rgb):
+    """HSL lightness L = (max(R,G,B) + min(R,G,B)) / 2; rgb is (n, 3)."""
+    rgb = np.asarray(rgb, dtype=float)
+    mx = np.max(rgb, axis=1)
+    mn = np.min(rgb, axis=1)
+    return (mx + mn) * 0.5
+
+
+def _resample_uniform_hsl_lightness(rgb_dense, n_samples, rgb_mix=1e-4):
     """
-    Resample points so consecutive rows are approximately equally spaced
-    in Euclidean RGB along the polyline through rgb_dense.
+    Resample the polyline through rgb_dense so LUT steps advance ~uniformly
+    in cumulative |ΔL| along the path, where L is HSL lightness (the same L as
+    in ``colorsys.rgb_to_hls``). Grays (R=G=B) lie on the RGB diagonal and have
+    L=t. A small Euclidean RGB term keeps spacing well-defined where L is
+    flat along saturated segments (uniform Bézier t still bunches there).
     """
     n_samples = int(n_samples)
     rgb_dense = np.asarray(rgb_dense, dtype=float)
@@ -36,9 +47,15 @@ def _arc_length_uniform_rgb(rgb_dense, n_samples):
         raise ValueError('n_samples must be at least 2')
     if len(rgb_dense) < 2:
         return np.repeat(rgb_dense[:1], n_samples, axis=0)
-    seg_len = np.linalg.norm(np.diff(rgb_dense, axis=0), axis=1)
-    cum = np.concatenate([[0.0], np.cumsum(seg_len)])
+    L = _hsl_lightness_rgb(rgb_dense)
+    dL = np.abs(np.diff(L))
+    drgb = np.linalg.norm(np.diff(rgb_dense, axis=0), axis=1)
+    seg = dL + rgb_mix * drgb
+    cum = np.concatenate([[0.0], np.cumsum(seg)])
     s_max = cum[-1]
+    if s_max <= 0:
+        cum = np.concatenate([[0.0], np.cumsum(drgb)])
+        s_max = cum[-1]
     targets = np.linspace(0.0, s_max, n_samples)
     return np.column_stack([
         np.interp(targets, cum, rgb_dense[:, 0]),
@@ -184,9 +201,11 @@ def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
     weight : float, optional
         Rational Bézier weight on the middle control point for each smooth
         segment through the RGB cube (default 1). Larger values pull the path
-        toward the middle control; sampling uses arc length in RGB so lookup
-        steps stay evenly spaced along the path (uniform Bézier parameter
-        would bunch samples toward the endpoints).
+        toward the middle control. Lookup rows are resampled from a dense
+        uniform-`t` Bézier using ~uniform steps in cumulative HSL lightness
+        change along the path (with a tiny RGB chord term where L is flat),
+        instead of uniform `t` (which bunches samples toward the endpoints;
+        see issue #2).
 
     Returns
     -------
@@ -265,16 +284,16 @@ def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
     p_end2 = np.asarray(data[4], dtype=float)
 
     n_half = lutsize // 2
-    # Dense uniform t, then arc-length resample so LUT steps are evenly spaced in RGB
-    # (uniform Bézier parameter bunches samples toward the endpoints on rational quadratics).
+    # Dense uniform t, then resample by cumulative |Δ HSL lightness| along the path
+    # (uniform Bézier t bunches samples toward the endpoints on rational quadratics).
     n_dense = max(8192, lutsize * 64)
     t_dense = np.linspace(0.0, 1.0, n_dense)
 
     rgb1_dense = _ratquad_bezier_rgb(p0, p_mid1, p_end1, weight, t_dense)
     rgb2_dense = _ratquad_bezier_rgb(p0, p_mid2, p_end2, weight, t_dense)
 
-    rgb1 = _arc_length_uniform_rgb(rgb1_dense, n_half)
-    rgb2 = _arc_length_uniform_rgb(rgb2_dense, n_half)
+    rgb1 = _resample_uniform_hsl_lightness(rgb1_dense, n_half)
+    rgb2 = _resample_uniform_hsl_lightness(rgb2_dense, n_half)
 
     ynew = np.concatenate((rgb1[1:][::-1], rgb2))
     np.clip(ynew, 0.0, 1.0, out=ynew)

--- a/bipolar.py
+++ b/bipolar.py
@@ -14,6 +14,39 @@ import scipy.interpolate
 from matplotlib import cm
 
 
+def _ratquad_bezier_rgb(p0, p1, p2, w, t):
+    """Rational quadratic Bézier in RGB; p* are shape (3,), t is 1d."""
+    t = np.asarray(t, dtype=float)
+    om = 1.0 - t
+    den = om * om + 2.0 * w * om * t + t * t
+    num = ((om[:, np.newaxis] ** 2) * p0
+           + (2.0 * w * om[:, np.newaxis] * t[:, np.newaxis]) * p1
+           + (t[:, np.newaxis] ** 2) * p2)
+    return num / den[:, np.newaxis]
+
+
+def _arc_length_uniform_rgb(rgb_dense, n_samples):
+    """
+    Resample points so consecutive rows are approximately equally spaced
+    in Euclidean RGB along the polyline through rgb_dense.
+    """
+    n_samples = int(n_samples)
+    rgb_dense = np.asarray(rgb_dense, dtype=float)
+    if n_samples < 2:
+        raise ValueError('n_samples must be at least 2')
+    if len(rgb_dense) < 2:
+        return np.repeat(rgb_dense[:1], n_samples, axis=0)
+    seg_len = np.linalg.norm(np.diff(rgb_dense, axis=0), axis=1)
+    cum = np.concatenate([[0.0], np.cumsum(seg_len)])
+    s_max = cum[-1]
+    targets = np.linspace(0.0, s_max, n_samples)
+    return np.column_stack([
+        np.interp(targets, cum, rgb_dense[:, 0]),
+        np.interp(targets, cum, rgb_dense[:, 1]),
+        np.interp(targets, cum, rgb_dense[:, 2]),
+    ])
+
+
 def bipolar(lutsize=256, neutral=1/3, interp=None):
     """
     Bipolar hot/cold colormap, with neutral central color.
@@ -123,7 +156,7 @@ def bipolar(lutsize=256, neutral=1/3, interp=None):
                                                        lutsize)
 
 
-def hotcold(lutsize=256, neutral=1/3, interp=None):
+def hotcold(lutsize=256, neutral=1/3, interp=None, weight=1.0):
     """
     Bipolar hot/cold colormap, with neutral central color.
 
@@ -147,11 +180,13 @@ def hotcold(lutsize=256, neutral=1/3, interp=None):
         For 2D heat maps, a `neutral` near the 0 or 1 extremes is better, for
         maximizing luminance change and showing details of the data.
     interp : str or int, optional
-        Specifies the type of interpolation.
-        ('linear', 'nearest', 'zero', 'slinear', 'quadratic, 'cubic')
-        or as an integer specifying the order of the spline interpolator
-        to use. Default is 'linear' for dark neutral and 'cubic' for light
-        neutral.  See `scipy.interpolate.interp1d`.
+        Accepted for API compatibility with :func:`bipolar`; ignored here.
+    weight : float, optional
+        Rational Bézier weight on the middle control point for each smooth
+        segment through the RGB cube (default 1). Larger values pull the path
+        toward the middle control; sampling uses arc length in RGB so lookup
+        steps stay evenly spaced along the path (uniform Bézier parameter
+        would bunch samples toward the endpoints).
 
     Returns
     -------
@@ -220,55 +255,29 @@ def hotcold(lutsize=256, neutral=1/3, interp=None):
     else:
         raise ValueError('n must be 0.0 < n < 1.0')
 
-    t = np.linspace(0, 1, lutsize//2)
+    if weight <= 0:
+        raise ValueError('weight must be positive')
 
-    # Super ugly Bezier curve
-    # Do 2, one for each half, from nnn to 100 and from 001 to nnn
+    p0 = np.asarray(data[2], dtype=float)
+    p_mid1 = np.asarray(data[1], dtype=float)
+    p_end1 = np.asarray(data[0], dtype=float)
+    p_mid2 = np.asarray(data[3], dtype=float)
+    p_end2 = np.asarray(data[4], dtype=float)
 
-    x1 = data[2][0]
-    y1 = data[2][1]
-    z1 = data[2][2]
+    n_half = lutsize // 2
+    # Dense uniform t, then arc-length resample so LUT steps are evenly spaced in RGB
+    # (uniform Bézier parameter bunches samples toward the endpoints on rational quadratics).
+    n_dense = max(8192, lutsize * 64)
+    t_dense = np.linspace(0.0, 1.0, n_dense)
 
-    xc = data[1][0]
-    yc = data[1][1]
-    zc = data[1][2]
+    rgb1_dense = _ratquad_bezier_rgb(p0, p_mid1, p_end1, weight, t_dense)
+    rgb2_dense = _ratquad_bezier_rgb(p0, p_mid2, p_end2, weight, t_dense)
 
-    x2 = data[0][0]
-    y2 = data[0][1]
-    z2 = data[0][2]
-
-    w = 1  # weight
-
-    r1 = (((1 - t)**2*x1 + 2*(1 - t)*t*w*xc + t**2*x2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-    g1 = (((1 - t)**2*y1 + 2*(1 - t)*t*w*yc + t**2*y2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-    b1 = (((1 - t)**2*z1 + 2*(1 - t)*t*w*zc + t**2*z2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-
-    x1 = data[2][0]
-    y1 = data[2][1]
-    z1 = data[2][2]
-
-    xc = data[3][0]
-    yc = data[3][1]
-    zc = data[3][2]
-
-    x2 = data[4][0]
-    y2 = data[4][1]
-    z2 = data[4][2]
-
-    r2 = (((1 - t)**2*x1 + 2*(1 - t)*t*w*xc + t**2*x2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-    g2 = (((1 - t)**2*y1 + 2*(1 - t)*t*w*yc + t**2*y2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-    b2 = (((1 - t)**2*z1 + 2*(1 - t)*t*w*zc + t**2*z2) /
-          ((1 - t)**2 + 2*(1 - t)*t*w + t**2))
-
-    rgb1 = np.dstack((r1, g1, b1))[0]
-    rgb2 = np.dstack((r2, g2, b2))[0]
+    rgb1 = _arc_length_uniform_rgb(rgb1_dense, n_half)
+    rgb2 = _arc_length_uniform_rgb(rgb2_dense, n_half)
 
     ynew = np.concatenate((rgb1[1:][::-1], rgb2))
+    np.clip(ynew, 0.0, 1.0, out=ynew)
 
     return cm.colors.LinearSegmentedColormap.from_list('hotcold', ynew,
                                                        lutsize)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [issue #2](https://github.com/endolith/bipolar-colormap/issues/2): uniform rational-quadratic parameter `t` bunches LUT samples toward the Bézier endpoints.

## Approach

1. Evaluate each half-path on a dense uniform-`t` grid (`n_dense = max(8192, lutsize * 64)`).
2. **Resample** to `lutsize // 2` rows by **cumulative** \(\sum |\Delta m|\) along that polyline, with **`m = (R+G+B)/3`**: linear spacing along the **achromatic (grayscale) diagonal** in RGB. For grays `R=G=B=t`, this is exactly `t` along the cube diagonal from black to white.
3. Add a small **Euclidean RGB chord** term when `m` is nearly flat so the parameterization still advances along saturated legs; if the combined metric collapses, **fall back** to pure RGB chord cumulative length.

## Why not “just Euclidean RGB distance”?

Euclidean distance in \(\mathbb{R}^3\) measures **all** channel motion. The colormap path also moves **perpendicular** to the gray direction (chroma). You can take a long step in RGB while **`m = (R+G+B)/3`** barely changes, or change **`m`** a lot with a modest 3D step. Equal spacing in **3D chord length** is therefore not the same as equal spacing in **`m`** along the path.

**RGB chord** here means the straight **segment** between consecutive points on the dense polyline in RGB space (a chord of the approximated curve); its length is \(\| \mathbf{c}_{i+1} - \mathbf{c}_i \|\).

## API

- **`weight`** (default `1.0`): rational quadratic weight on the middle control (replaces hardcoded `w = 1`).
- **`interp`**: still accepted for parity with `bipolar()`; ignored in `hotcold()` (documented).

## Notes

- RGB is clipped to `[0, 1]` after resampling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e871d8a-3118-471d-9651-cd91212234ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e871d8a-3118-471d-9651-cd91212234ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

